### PR TITLE
[FEATURE] Add a more extensive CLI suite

### DIFF
--- a/gerber2nc.py
+++ b/gerber2nc.py
@@ -15,6 +15,15 @@ import sys, re, math
 from shapely.geometry import LineString, MultiLineString, Point, box
 from shapely.ops import unary_union
 
+# Argument Parsing/CLI imports
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from pathlib import Path
+
+# For calculating extents of the board
+X_MIN:float = 1000000.0
+X_MAX:float = -1000000.0
+Y_MIN:float = 1000000.0
+Y_MAX:float = -1000000.0
 
 class Gerber_Traces_Parser:
     def __init__(self, filename: str):

--- a/gerber2nc.py
+++ b/gerber2nc.py
@@ -701,10 +701,10 @@ def run():
     else:
         out_file = Path(out_file).with_suffix('.nc')
 
-# Use KiCad's naming convention to  get the copper front layer, ege cuts, and drill files.
-gerber_traces = Gerber_Traces_Parser(base_name+"-F_Cu.gbr")
-gerber_edgecuts = Gerber_EdgeCuts_Parser(base_name+"-Edge_cuts.gbr")
-drilldata = Drillfile_Parser(base_name+"-PTH.drl")
+    # Use KiCad's naming convention to  get the copper front layer, ege cuts, and drill files.
+    gerber_traces = Gerber_Traces_Parser(str(next(project.glob('*-F*Cu.g*'))))
+    gerber_edgecuts = Gerber_EdgeCuts_Parser(str(next(project.glob('*-Edge*uts.g*'))))
+    drilldata = Drillfile_Parser(str(next(project.glob('*-PTH.drl'))))
 
     # Offset all the coordinates so that the origin is on the bottom left.
     # Set the CNC origin to the botom left corner of where your PCB should be milled.

--- a/gerber2nc.py
+++ b/gerber2nc.py
@@ -432,17 +432,21 @@ class Output_visualizer:
 
 #=========================================================================================
 class Gcode_Generator:
-    def __init__(self):
+    def __init__(self, spindle_speed: int, cut_depth: float,
+                 edge_cut_depth: float, safe_height: float, 
+                 plunge_feed_rate: int, feed_rate: int, 
+                 hole_start: float, hole_depth: float):
+        
         # Milling parameters
-        self.spindle_speed = 12000  # RPM
-        self.cut_depth = -0.1       # mm (for outlinding traces)
-        self.edge_cut_depth = -0.2  # mm For PCB outline
-        self.safe_height = 3.0      # mm above workpiece
-        self.plunge_feed_rate = 200 # mm/min
-        self.feed_rate = 450        # mm/min
+        self.spindle_speed = spindle_speed       # RPM
+        self.cut_depth = cut_depth               # mm (for outlinding traces)
+        self.edge_cut_depth = edge_cut_depth     # mm For PCB outline
+        self.safe_height = safe_height           # mm above workpiece
+        self.plunge_feed_rate = plunge_feed_rate # mm/min
+        self.feed_rate = feed_rate               # mm/min
 
-        self.hole_start = 0.1       # Depth to go to before slow drilling
-        self.hole_depth = -1.8      # Final depth to make it through the PCB
+        self.hole_start = hole_start             # Depth to go to before slow drilling
+        self.hole_depth = hole_depth             # Final depth to make it through the PCB
 
 
     def OutputGcode (self, filename:str, edgecuts:list, trace_mill_geometry, holes:list):

--- a/gerber2nc.py
+++ b/gerber2nc.py
@@ -694,7 +694,9 @@ def run():
         passes, path_spacing
     ) = get_args(parser)
 
-    project = Path(in_proj)
+    # Remove any suffix from the path in case the project file was passed
+    project = Path(in_proj).with_suffix('')
+
     # Cast the outfile to a path
     if out_file == 'project name':
         out_file = Path(project.stem).with_suffix('.nc')


### PR DESCRIPTION
Changing parameters in several places in the current codebase is a bit of a pain. I went ahead and used the argparse module to expand the CLI to accept typed flags for most milling parameters.

This means that now you dont even need to save the file to change something, just hit up arrow and change the value passed to the flag!

Here's the help message:

```
usage: gerber2nc [-h] [-s ] [-c ] [-e ] [-g ] [-z ] [-r ] [-t ] [-d ] [-o ] [-p ] [-v ] project outfile

positional arguments:
  project               Filepath of the KiCAD project to convert e.g. **/myproject.kicad_pro
  outfile               Target for the generated numerical control (.nc) file [optional]

options:
  -h, --help            show this help message and exit

Milling Configuration:
  -s, --spindle-speed   Spindle speed in RPM (default: 12000)
  -c, --cut-depth       Cut depth for outlining traces (mm) (default: -0.1)
  -e, --edge-depth      Edge cut depth for PCB outline (mm) (default: -0.2)
  -g, --safe-height     Safe height above workpiece (mm) (default: 3.0)
  -z, --z-feed-rate     Feedrate along Z axis (mm/min) (default: 200)
  -r, --feed-rate       Feedrate along X/Y (mm/min) (default: 450)
  -t, --hole-start      Top depth to start slow drilling holes (mm) (default: 0.1)
  -d, --hole-depth      Depth at which a hole is complete likely workpiece thickness (mm) (default: -1.8)
  -o, --offset-dist     Offset of initial path from trace or pad edge (mm) (default: 0.22)
  -p, --passes          Number of passes to take around traces (default: 3)
  -v, --path-spacing    Additional pass offset (mm) (default: 0.2)
```

No changes were made to the parsing and generating code, only to the CLI. With the exception of capitalizing the X/Y MIN/MAX globals and moving them to the top of the file. I also made the Visualizer and Generator take arguments instead of hardcoding the __init__ attributes.